### PR TITLE
txt -> html report

### DIFF
--- a/qtp_sequencing/summary.py
+++ b/qtp_sequencing/summary.py
@@ -228,7 +228,7 @@ def _summary_FASTA_preprocessed(artifact_type, filepaths, out_dir):
             "Std out: %s\nStd err: %s\n\nCommand run was:\n%s" % (
                 std_out, std_err, cmd))
     else:
-        with open(f'{out_dir}/quast/report.txt', 'r') as f:
+        with open(f'{out_dir}/quast/report.html', 'r') as f:
             artifact_information = f.readlines()
 
     return artifact_information

--- a/qtp_sequencing/tests/test_summary.py
+++ b/qtp_sequencing/tests/test_summary.py
@@ -290,12 +290,9 @@ class SummaryTestsNotDemux(PluginTestCase):
 
         obs = _summary_FASTA_preprocessed(
             artifact_type, files, self.out_dir)
-        exp = ['All statistics are based on contigs of size >= 500 bp, unless '
-               'otherwise noted (e.g., "# contigs (>= 0 bp)" and "Total '
-               'length (>= 0 bp)" include all contigs).\n', '\n', 'Assembly   '
-               '                 s1       s2       s3       s4     \n',
-               '# contigs (>= 0 bp)         2550     2550     2550     '
-               '2550   \n']
+        exp = ['<!DOCTYPE html>\n', '<html lang="en">\n', '<head>\n',
+               '    <meta http-equiv="Content-Type" content="text/html;'
+               'charset=utf-8" >\n']
         self.assertEqual(obs[:4], exp)
 
 


### PR DESCRIPTION
The txt for quast summary looks pretty bad online, adding the html report, which looks much better. 